### PR TITLE
Throw Exception if metal:use-macro and metal:define-macro both specified for the same element

### DIFF
--- a/classes/PHPTAL/Php/Attribute/METAL/UseMacro.php
+++ b/classes/PHPTAL/Php/Attribute/METAL/UseMacro.php
@@ -52,6 +52,14 @@ class PHPTAL_Php_Attribute_METAL_UseMacro extends PHPTAL_Php_Attribute
 
         $macroname = strtr($this->expression, '-', '_');
 
+	// throw error if attempting to define and use macro at same time
+	// [should perhaps be a TemplateException? but I don't know how to set that up...]
+	if ($defineAttr = $this->phpelement->getAttributeNodeNS(
+		'http://xml.zope.org/namespaces/metal', 'define-macro')) {
+		if ($defineAttr->getValue() == $macroname) 
+			throw new Exception("Cannot simultaneously define and use macro '$macroname'");
+	}
+
         // local macro (no filename specified) and non dynamic macro name
         // can be called directly if it's a known function (just generated or seen in previous compilation)
         if (preg_match('/^[a-z0-9_]+$/i', $macroname) && $codewriter->functionExists($macroname)) {


### PR DESCRIPTION
Fix for an unusual edge case (but tripped me up ;) ): Throws an exception if metal:use-macro and metal:define-macro both specified for the same element.
(I had mis-coded a PreFilter so it was generating both which is how I discovered this).
(Previously this seemed to cause the page to hang and is certainly an error condition anyway.)
