### PR TITLE
Now throws PHPTal_TemplateException when using metal:define-macro & metal:use-macro

### DIFF
--- a/classes/PHPTAL/Php/Attribute/METAL/UseMacro.php
+++ b/classes/PHPTAL/Php/Attribute/METAL/UseMacro.php
@@ -57,7 +57,8 @@ class PHPTAL_Php_Attribute_METAL_UseMacro extends PHPTAL_Php_Attribute
 	if ($defineAttr = $this->phpelement->getAttributeNodeNS(
 		'http://xml.zope.org/namespaces/metal', 'define-macro')) {
 		if ($defineAttr->getValue() == $macroname) 
-			throw new Exception("Cannot simultaneously define and use macro '$macroname'");
+            		throw new PHPTAL_TemplateException("Cannot simultaneously define and use macro '$macroname'",
+                		$this->phpelement->getSourceFile(), $this->phpelement->getSourceLine());			
 	}
 
         // local macro (no filename specified) and non dynamic macro name


### PR DESCRIPTION
Now throws PHPTal_TemplateException for error thrown when simultaneously
using metal:define-macro and metal:use-macro for the same macro.
(Passes line # and file of error location so the exception will show these)
