### PR TITLE
Adding first composer setup definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "phptal/phptal",
     "homepage": "http://phptal.org/",
     "description": "PHPTAL is a templating engine for PHP5 that implements Zope Page Templates syntax",
+    "license": "LGPLv2",
     "type": "library",
     "keywords": [
         "zope",


### PR DESCRIPTION
This feature makes phptal installable via [composer](https://github.com/composer/composer) and available on [packagist.org](http://packagist.org/).
