### PR TITLE
Allow backslashes in tales modifiers, so we can use namespaced classes.

### DIFF
--- a/classes/PHPTAL/Php/TalesInternal.php
+++ b/classes/PHPTAL/Php/TalesInternal.php
@@ -461,8 +461,8 @@ class PHPTAL_Php_TalesInternal implements PHPTAL_Tales
     {
         $expression = trim($expression);
 
-        // Look for tales modifier (string:, exists:, etc...)
-        if (preg_match('/^([a-z](?:[a-z0-9._-]*[a-z0-9])?):(.*)$/si', $expression, $m)) {
+        // Look for tales modifier (string:, exists:, Namespaced\Tale:, etc...)
+        if (preg_match('/^([a-z](?:[a-z0-9._\\\\-]*[a-z0-9])?):(.*)$/si', $expression, $m)) {
             list(, $typePrefix, $expression) = $m;
         }
         // may be a 'string'


### PR DESCRIPTION
This patch simply allows the blackslash to be used in TALES, e.g.

```
<tal:inline tal:content="Ztal\Tales\Generic.someMethod:input1,input2" />
```
