### PR TITLE
Install PHPUnit via Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 /composer.lock
 /doc/temp/
 /docs/
+/tools/phpunit

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
     "require": {
         "php": ">=5.1.2"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~3.7.0"
+    },
     "autoload": {
         "psr-0": {
             "PHPTAL": "classes/"


### PR DESCRIPTION
For ease of testing I suggest including PHPUnit in Composer. Some users might not use PEAR anymore, but we can expect Composer to them.
