### PR TITLE
Use preg_replace_callback instead of preg_replace

### DIFF
--- a/tests/HTML5ModeTest.php
+++ b/tests/HTML5ModeTest.php
@@ -185,9 +185,20 @@ class HTML5ModeTest extends PHPTAL_TestCase
        $this->assertEquals('<input checked="checked"/>',$tpl->execute());
    }
 
+   /**
+    * @param string $str
+    */
    private function decodeNumericEntities($str)
    {
-       return normalize_html(@preg_replace('/&#x?[a-f0-9]+;/ie','htmlspecialchars(html_entity_decode("\\0"))', $str));
+       return normalize_html(
+           preg_replace_callback(
+       	'/&#x?[a-f0-9]+;/i',
+               function (array $entities) {
+                   return htmlspecialchars(html_entity_decode($entities[0]));
+               },
+       	$str
+           )
+       );
    }
 
    function testAttributeQuotes()


### PR DESCRIPTION
Use preg_replace_callback instead of just suppressing the preg_replace \e modifier deprecation warning
