### PR TITLE
Add support for subpaths in the codedestination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 /doc/temp/
 /docs/
 /tools/phpunit
+*.swo
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ build
 /doc/temp/
 /docs/
 /tools/phpunit
-*.swo
-*.swp

--- a/tests/PhptalTest.php
+++ b/tests/PhptalTest.php
@@ -286,4 +286,43 @@ class PhptalTest extends PHPTAL_TestCase
 
         $this->assertContains('DOCTYPE',$res);
     }
+
+    public function testGetSubpathPrefixReturnsDefault() {
+	$tpl = $this->newPHPTAL();
+
+	$this->assertEquals('phptal_', $tpl->getSubpathPrefix());
+    }
+
+    public function testGetSubpathPrefixReturnsNewValue() {
+	$tpl = $this->newPHPTAL();
+
+	$new_prefix = 'this-is-my-prefix';
+	$tpl->setSubpathPrefix($new_prefix);
+
+	$this->assertEquals($new_prefix, $tpl->getSubpathPrefix());
+    }
+
+    public function testGetSubpathAmountReturnsDefault() {
+	$tpl = $this->newPHPTAL();
+
+	$this->assertEquals(0, $tpl->getSubpathAmount());
+    }
+
+    public function testGetSubpathAmountReturnsNewValue() {
+	$tpl = $this->newPHPTAL();
+
+	$new_limit = 11;
+	$tpl->setSubpathAmount($new_limit);
+
+	$this->assertEquals($new_limit, $tpl->getSubpathAmount());
+    }
+
+    public function testSetSubpathAmountRespectsLimit() {
+	$tpl = $this->newPHPTAL();
+
+	$new_limit = 42;
+	$tpl->setSubpathAmount($new_limit);
+
+	$this->assertEquals(PHPTAL::SUBPATH_LIMIT, $tpl->getSubpathAmount());
+    }
 }


### PR DESCRIPTION
When using tal with a high amount of different templates and macros (I'm talking about millions of different templates), the code destination folder gets filled up with cache files within no time - especially if you dont want to clear the directory every 10 minutes. This slows down the filesystem access to the specific directory (depends on the environment - filesystemtype, nfs, etc.).

This patch introduces a configurable level of subpaths which are added to the phpCodeDestination to create a structure of max 32 subpaths with 0 as default to avoid impacts on existing installations.
