### PR TITLE
Adding PHPTAL_lint to bin directoy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ matrix:
   allow_failures:
     - php: 5.2
 
-script: phpunit -c phpunit.xml
+script: 
+    - phpunit -c phpunit.xml
+    - tools/phptal_lint.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ matrix:
   allow_failures:
     - php: 5.2
 
-script: phpunit -c phpunit.xml
+script:
+    - phpunit -c phpunit.xml
+    - phptal_lint.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ matrix:
 
 script: 
     - phpunit -c phpunit.xml
-    - tools/phptal_lint.php -e html tests/input/
+    - tools/phptal_lint.php -e html tests/input/phptal*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ matrix:
 
 script: 
     - phpunit -c phpunit.xml
-    - tools/phptal_lint.php
+    - tools/phptal_lint.php -e html tests/input/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,4 @@ matrix:
   allow_failures:
     - php: 5.2
 
-script:
-    - phpunit -c phpunit.xml
-    - phptal_lint.php
+script: phpunit -c phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,8 @@
     },
     "config": {
         "bin-dir": "tools"
-    }
+    },
+    "bin": [
+        "tools/phptal_lint.php"
+    ]
 }


### PR DESCRIPTION
Installs the lint tool in the composer bin directory.

I wasn't sure whether to rename `phptal_lint.php` to `phptal_lint` as other tools don't have the .php extension but I thought it was best to leave it for now in case anyone is using any test tools which expect `tools/phptal_lint.php` to exist