### PR TITLE
Make sure the locales used in the tests are installed in the Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,13 @@ matrix:
   allow_failures:
     - php: 5.2
 
-script: phpunit -c phpunit.xml
+before_script:
+  # Make sure the locales used in the tests are installed
+  - sudo locale-gen en_GB
+  - sudo locale-gen en_GB.utf8
+  - sudo locale-gen fr_FR
+  - sudo locale-gen fr_FR@euro
+  - sudo locale-gen fr_FR.utf8
+
+script:
+  - phpunit -c phpunit.xml


### PR DESCRIPTION
As became apparent in #49, "something" changed in the Travis-CI environment that caused the build to break because tests suddenly started failing.

This seemed to have something to do with the locales. Listing all of the locales installed on the Travis machine corroborated this:
```bash
$ locale -a
C
C.UTF-8
en_US.utf8
POSIX
pt_BR.utf8
pt_PT.utf8
```

The most simple solution seemed to be: making sure all of the needed locales were available by explicitly installing them. This can easily be achieved by adding the install commands to the Travis configuration file, in a `before_script` step.

This pull request does that.

@Ocramius Are we good to merge, or did I miss anything?