### PR TITLE
Fixed false positive ClamAV bug in SaxXmlParser.php

### DIFF
--- a/classes/PHPTAL/Dom/SaxXmlParser.php
+++ b/classes/PHPTAL/Dom/SaxXmlParser.php
@@ -424,7 +424,8 @@ class PHPTAL_Dom_SaxXmlParser
      */
     private static function convertBytesToEntities(array $m)
     {
-        $m = $m[1]; $out = '';
+        $m = $m[1];
+        $out = "";
         for($i=0; $i < strlen($m); $i++)
         {
             $out .= '&#X'.strtoupper(dechex(ord($m[$i]))).';';


### PR DESCRIPTION
- Fixed false positive ClamAV bug in the SaxXmlParser thanks to @iman61

See Issue:
https://github.com/phptal/PHPTAL/issues/56


Scan result after the fix (**files 499, malware hits 0, cleaned hits 0,  time 9s**):

```
[bram@nerd ~]$ maldet -u && maldet -d
Linux Malware Detect v1.6.1
            (C) 2002-2017, R-fx Networks <proj@rfxn.com>
            (C) 2017, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(27091): {sigup} performing signature update check...
maldet(27091): {sigup} local signature set is version 2017051530038
maldet(27091): {sigup} latest signature set already installed
Linux Malware Detect v1.6.1
            (C) 2002-2017, R-fx Networks <proj@rfxn.com>
            (C) 2017, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(27191): {update} checking for available updates...
maldet(27191): {update} hashing install files and checking against server...
/usr/local/maldetect/internals/functions: line 1842: /usr/local/maldetect/internals/VERSION.hash: Permission denied
maldet(27191): {update} latest version already installed.
[bram@nerd ~]$ maldet -a /home/bram/PHPTAL/
Linux Malware Detect v1.6.1
            (C) 2002-2017, R-fx Networks <proj@rfxn.com>
            (C) 2017, Ryan MacDonald <ryan@rfxn.com>
This program may be freely redistributed under the terms of the GNU GPL v2

maldet(27408): {scan} signatures loaded: 16561 (13831 MD5 | 1951 HEX | 779 YARA | 0 USER)
maldet(27408): {scan} building file list for /home/bram/PHPTAL/, this might take awhile...
maldet(27408): {scan} setting nice scheduler priorities for all operations: cpunice 19 , ionice 6
maldet(27408): {scan} file list completed in 0s, found 499 files...
maldet(27408): {scan} found clamav binary at /usr/bin/clamscan, using clamav scanner engine...
maldet(27408): {scan} scan of /home/bram/PHPTAL/ (499 files) in progress...
maldet(27408): {scan} clamscan returned an error, check /usr/local/maldetect/pub/bram/clamscan_log for more details!

maldet(27408): {scan} scan completed on /home/bram/PHPTAL/: files 499, malware hits 0, cleaned hits 0,  time 9s
```