### PR TITLE
Fixed warning "continue" with php >= 7.3

### DIFF
--- a/classes/PHPTAL/Php/Transformer.php
+++ b/classes/PHPTAL/Php/Transformer.php
@@ -74,7 +74,7 @@ class PHPTAL_Php_Transformer
                     {
                         $result .= $prefix;
                         $state = self::ST_NONE;
-                        continue;
+                        break;
                     }
                     /* NO BREAK - ST_WHITE is almost the same as ST_NONE */
 


### PR DESCRIPTION
PHP 7.3 warnings, when `continue` is used within switch.
So I replaced `continue` to `break`.