### PR TITLE
travis require precise to php 5.3.x environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ language: php
 
 php:
   - 5.2
-  - 5.3.3
-  - 5.3
   - 5.4
   - 5.5
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.3.3
+      dist: precise
   allow_failures:
     - php: 5.2
 


### PR DESCRIPTION
PHP 5.3, 5.3.3 environments are needs to `precise`. 