### PR TITLE
fix(Transformer): PHP 7.3 warning

### DIFF
--- a/classes/PHPTAL/Php/Transformer.php
+++ b/classes/PHPTAL/Php/Transformer.php
@@ -74,7 +74,7 @@ class PHPTAL_Php_Transformer
                     {
                         $result .= $prefix;
                         $state = self::ST_NONE;
-                        continue;
+                        break;
                     }
                     /* NO BREAK - ST_WHITE is almost the same as ST_NONE */
 


### PR DESCRIPTION
fixes the `Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?` warning